### PR TITLE
Add shebang

### DIFF
--- a/tailscale-hostmap.py
+++ b/tailscale-hostmap.py
@@ -1,3 +1,5 @@
+#!/bin/env python3
+
 import json
 import argparse
 import subprocess


### PR DESCRIPTION
This adds the shebang to directly execute this script (if it is executable) with the available system python interpreter. This works on most Unix system (there are exceptions where env is not in that path).

Reference:
https://docs.python.org/3.10/using/windows.html#shebang-lines